### PR TITLE
chore: move vue to dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "rollup-plugin-external-globals": "^0.6.1",
     "rollup-plugin-terser": "^7.0.2",
     "vite": "^3.0.0",
-    "vite-plugin-static-copy": "^0.7.0"
+    "vite-plugin-static-copy": "^0.7.0",
+    "vue": "^3.2.37"
   },
   "author": "John Prem Kumar S",
   "license": "MIT",
   "dependencies": {
-    "favicons": "^7.0.0-beta.4",
-    "vue": "^3.2.37"
+    "favicons": "^7.0.0-beta.4"
   }
 }


### PR DESCRIPTION
I haven't seen something that depends on vue in the src-folder.
Declaring vue as a dev-dependency would save me some issues with vue-incompatibillities on a vue-2 project.