### PR TITLE
fix: Don't process closeBundle if called with an error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,10 @@ const vitePluginFaviconsInject = (inputSource, inputConfig = {}, pluginInputConf
         throw err;
       });
     },
-    closeBundle() {
+    closeBundle(error) {
+      if (error) {
+        return;
+      }
       const fileCreationPromise = [];
       const { files } = response;
       const { images } = response;


### PR DESCRIPTION
If an error occurred during build (in parts unrelated to this plugin), the `flowPromise` might not have been resolved when `closeBundle` gets called. Inside of `closeBundle`, using `files` then leads to another error, which masks the original error. 

To prevent this, check whether an error has occurred and stop processing `closeBundle` in that case.